### PR TITLE
NO_MERGE: PoC: Add support of Generating stubs for Pipeline Library global vars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1105,11 +1105,11 @@
       </site>
       <repository>
         <id>maven.jenkins-ci.org</id>
-        <url>http://maven.jenkins-ci.org:8081/content/repositories/releases</url>
+        <url>https://repo.jenkins-ci.org/releases</url>
       </repository>
       <snapshotRepository>
         <id>maven.jenkins-ci.org</id>
-        <url>http://maven.jenkins-ci.org:8081/content/repositories/snapshots</url>
+        <url>https://repo.jenkins-ci.org/snapshots</url>
       </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -584,7 +584,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.8</version>
                     <configuration>
-                        <source>1.4</source>
+                        <source>1.7</source>
                     </configuration>
                 </plugin>
 
@@ -646,7 +646,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.4, 1.8)</version>
+                                    <version>[1.7, 1.9)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[2.0.10,)</version>
@@ -675,8 +675,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.4</source>
-                    <target>1.4</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Just a dirty GMaven hack, which allows generating stubs for Pipeline Global vars.

- [x] - PoC
- [ ] - Productize and document the PoC

Format:

* Library classes didn't need any changes
* Global variables...
  * For each variable a meta-class is created in the `globalvars` package
  * There is a `Vars` class, which keeps references to all global variables

See the examples in the upstream PR: https://github.com/jenkins-infra/pipeline-library/pull/22